### PR TITLE
Expose base_name and generated_patches_dir

### DIFF
--- a/packages/open_vp_cal/src/open_vp_cal/framework/generation.py
+++ b/packages/open_vp_cal/src/open_vp_cal/framework/generation.py
@@ -1115,6 +1115,19 @@ class PatchGeneration:
 
     @staticmethod
     def base_name(led_wall: LedWallSettings) -> str:
+        """
+        Generates a standardized base name from LED wall settings.
+
+        The base name is used for:
+        - Directory name to store generated patches
+        - File name prefix for generated patch files
+
+        Parameters:
+            led_wall (LedWallSettings): The LED wall settings to generate base name from
+
+        Returns:
+            str: Formatted base name in the format "OpenVPCal_{wall_name}_{gamut}_{eotf}"
+        """
         led_wall_name_cleaned: str = utils.replace_non_alphanumeric(led_wall.name, "_")
         target_gamut_cleaned: str = utils.replace_non_alphanumeric(str(led_wall.target_gamut), "_")
         target_eotf_cleaned: str = utils.replace_non_alphanumeric(str(led_wall.target_eotf), "_")
@@ -1122,6 +1135,18 @@ class PatchGeneration:
 
     @staticmethod
     def generated_patches_dir(led_wall: LedWallSettings) -> str:
+        """
+        Constructs the full directory path where generated patches will be stored.
+
+        The directory structure follows the pattern:
+        {export_folder}/patches/{base_name}/{file_format}/
+
+        Parameters:
+            led_wall (LedWallSettings): The LED wall settings containing project configuration
+
+        Returns:
+            str: Full path to the directory where patch files should be generated
+        """
         return os.path.join(
             led_wall.project_settings.export_folder,
             constants.ProjectFolders.PATCHES,

--- a/tests/test_open_vp_cal/test_generation.py
+++ b/tests/test_open_vp_cal/test_generation.py
@@ -53,3 +53,19 @@ class TestGeneration(TestBase):
 
             comparison_image = os.path.join(reference_root_folder, base_name)
             self.compare_image_files(comparison_image, file_path, self.project_settings.file_format)
+
+    def test_base_name(self):
+        """Test The Base Name of the Led Wall Settings"""
+        self.assertEqual(PatchGeneration.base_name( self.led_wall),
+                         "OpenVPCal_Wall1_ITU_R_BT_2020_ST_2084")
+
+    def test_generated_patches_dir(self):
+        """Test The Generated Patches Directory of the Led Wall Settings"""
+        expected_generated_patches_dir = os.path.join(
+            self.led_wall.project_settings.export_folder,
+            "patches",
+            "OpenVPCal_Wall1_ITU_R_BT_2020_ST_2084",
+            "exr")
+
+        self.assertEqual(PatchGeneration.generated_patches_dir(self.led_wall),
+                         expected_generated_patches_dir)


### PR DESCRIPTION
# Expose base_name and generated_pathes_dir for PatchGeneration

## Summary

As the output directory for the generated patches are hard-coded, I've added a `PatchGeneration.base_name` and `PatchGeneration.generated_pathes_dir`.

`generate_patches` does return list of generated patch file paths; however, it gets lost when `generate_patterns_for_led_walls`is used to generate patches. With the new API, the directory can be easily accessed. 

- `TestGeneration` will cover this change.