### PR TITLE
fix deprecated colour.XYZ_to_RGB

### DIFF
--- a/packages/open_vp_cal/src/open_vp_cal/imaging/imaging_utils.py
+++ b/packages/open_vp_cal/src/open_vp_cal/imaging/imaging_utils.py
@@ -431,12 +431,10 @@ def generate_image_cie(scale: int, file_path: str) -> bool:
                 ]["D65"]
 
                 rgb = colour.XYZ_to_RGB(
-                    XYZ,
-                    illuminant,
-                    RGB_COLOURSPACE_ACES2065_1.whitepoint,
-                    RGB_COLOURSPACE_ACES2065_1.matrix_XYZ_to_RGB,
-                    "Cat02",
-                    None,
+                    XYZ=XYZ,
+                    colourspace = RGB_COLOURSPACE_ACES2065_1,
+                    illuminant = illuminant,
+                    chromatic_adaptation_transform="CAT02"
                 )
                 # rgb = [max(0, min(1, channel)) for channel in colour.XYZ_to_sRGB(XYZ)]
                 buf.setpixel(x_pos, y_pos, (rgb[0], rgb[1], rgb[2]))

--- a/packages/open_vp_cal/src/open_vp_cal/imaging/macbeth.py
+++ b/packages/open_vp_cal/src/open_vp_cal/imaging/macbeth.py
@@ -147,10 +147,9 @@ def get_rgb_references_for_color_checker(colour_space, illuminant=None):
     illuminant = illuminant if illuminant else colour_checker_reference.illuminant
     xyz_references = colour.xyY_to_XYZ(xyY_references)
     rgb_references = colour.XYZ_to_RGB(
-        xyz_references,
-        illuminant,
-        colour_space.whitepoint,
-        colour_space.matrix_XYZ_to_RGB,
+        XYZ=xyz_references,
+        colourspace=colour_space,
+        illuminant=illuminant
     )
     return rgb_references
 


### PR DESCRIPTION
# Fix deprecated colour.XYZ_to_RGB

## Summary

Existing `colour.XYZ_to_RGB` has been deprecated and need to be updated.

old version (before 0.4.3)

**Parameters:**
- `XYZ` (ArrayLike) – CIE XYZ tristimulus values.
- `illuminant_XYZ` (ArrayLike) – CIE xy chromaticity coordinates or CIE xyY colourspace array of the illuminant for the input CIE XYZ tristimulus values.
- `illuminant_RGB` (ArrayLike) – CIE xy chromaticity coordinates or CIE xyY colourspace array of the illuminant for the output RGB colourspace array.
- `matrix_XYZ_to_RGB` (ArrayLike) – Matrix converting the CIE XYZ tristimulus values to RGB colourspace array, i.e. the inverse Normalised Primary Matrix (NPM).
- `chromatic_adaptation_transform` (Literal['Bianco 2010', 'Bianco PC 2010', 'Bradford', 'CAT02 Brill 2008', 'CAT02', 'CAT16', 'CMCCAT2000', 'CMCCAT97', 'Fairchild', 'Sharp', 'Von Kries', 'XYZ Scaling'] | str | None) – Chromatic adaptation transform, if None no chromatic adaptation is performed.
- `cctf_encoding` (Callable | None) – Encoding colour component transfer function (Encoding CCTF) or opto-electronic transfer function (OETF).

new version (from 0.4.3)

**Parameters:**
- `XYZ` (ArrayLike) – CIE XYZ tristimulus values.
- `colourspace` (RGB_Colourspace | LiteralRGBColourspace | str) – Output RGB colourspace.
- `illuminant` (ArrayLike | None) – CIE xy chromaticity coordinates or CIE xyY colourspace array of the illuminant for the input CIE XYZ tristimulus values.
- `chromatic_adaptation_transform` (LiteralChromaticAdaptationTransform | str | None) – Chromatic adaptation transform, if None no chromatic adaptation is performed.
- `apply_cctf_encoding` (bool) – Apply the RGB colourspace encoding colour component transfer function / opto-electronic transfer function.
- `args` (Any) – Arguments for deprecation management.
- `kwargs` (Any) – Keywords arguments for deprecation management.