### PR TITLE
Fix deprecated colour.RGB_to_XYZ signature

### DIFF
--- a/packages/open_vp_cal/src/open_vp_cal/core/calibrate.py
+++ b/packages/open_vp_cal/src/open_vp_cal/core/calibrate.py
@@ -350,9 +350,7 @@ def extract_screen_cs(
 
     primaries_XYZ_calibrated = colour.RGB_to_XYZ(
         calibrated_saturated_primaries_target,
-        target_cs.whitepoint,
-        target_cs.whitepoint,
-        target_cs.matrix_RGB_to_XYZ
+        target_cs
     )
 
     # White Point
@@ -369,9 +367,7 @@ def extract_screen_cs(
 
     white_point_XYZ_calibrated = colour.RGB_to_XYZ(
         calibrated_white_point_target,
-        target_cs.whitepoint,
-        target_cs.whitepoint,
-        target_cs.matrix_RGB_to_XYZ
+        target_cs
     )
     white_point_xy_calibrated = colour.XYZ_to_xy(white_point_XYZ_calibrated)
 
@@ -1162,9 +1158,7 @@ def run(
 def convert_samples_to_xyY(samples, samples_color_space):
     XYZ_eotf = colour.RGB_to_XYZ(
         samples,
-        samples_color_space.whitepoint,
-        samples_color_space.whitepoint,
-        samples_color_space.matrix_RGB_to_XYZ
+        samples_color_space
     )
     # Convert rthe XYZ_eotf to xyY values
     xyY_eotf = colour.XYZ_to_xyY(XYZ_eotf)

--- a/packages/open_vp_cal/src/open_vp_cal/imaging/imaging_utils.py
+++ b/packages/open_vp_cal/src/open_vp_cal/imaging/imaging_utils.py
@@ -806,9 +806,7 @@ def convert_to_grayscale(input_image_buf, input_colour_space="sRGB") -> Oiio.Ima
 
     numpy_array_XYZ = colour.RGB_to_XYZ(
         flattened_arr,
-        input_colour_space_cs.whitepoint,
-        input_colour_space_cs.whitepoint,
-        input_colour_space_cs.matrix_RGB_to_XYZ
+        input_colour_space_cs
     )
     numpy_array_xyY = colour.XYZ_to_xyY(numpy_array_XYZ)
 
@@ -904,9 +902,7 @@ def _get_xyY_values(values: np.array, colour_space: str = "ACES2065-1") -> np.ar
     input_colour_space_cs = colour.RGB_COLOURSPACES[colour_space]
     numpy_array_XYZ = colour.RGB_to_XYZ(
         values,
-        input_colour_space_cs.whitepoint,
-        input_colour_space_cs.whitepoint,
-        input_colour_space_cs.matrix_RGB_to_XYZ
+        input_colour_space_cs
     )
 
     return colour.XYZ_to_xyY(numpy_array_XYZ)


### PR DESCRIPTION
# Fix deprecated colour.RGB_to_XYZ signature

## Summary

`colour.RGB_to_XYZ` signature has been changed with `colour v0.4.3`.
- https://github.com/colour-science/colour/issues/1127
- https://github.com/colour-science/colour/releases/tag/v0.4.3