### PR TITLE
Add rgba exr file support

### DIFF
--- a/packages/open_vp_cal/src/open_vp_cal/imaging/imaging_utils.py
+++ b/packages/open_vp_cal/src/open_vp_cal/imaging/imaging_utils.py
@@ -1023,7 +1023,8 @@ def apply_matrix_to_img_buf(
         Oiio.ImageBuf: The image buffer with the matrix applied
 
     """
-    frame_np_array = image_buf_to_np_array(image_buf)
+    # matrix is 3x3; hence, we should drop alpha channel and only use RGB channel
+    frame_np_array = image_buf_to_np_array(image_buf)[:, :, :3]
     image_reshaped = frame_np_array.reshape((-1, 3))
     white_balanced_image = image_reshaped @ matrix
     white_balanced_image = white_balanced_image.reshape(frame_np_array.shape)


### PR DESCRIPTION
# Add rgba exr file support

## Summary

the format of `matrix` passed as arg of `apply_matrix_to_img_buf` is 3x3.
As a result, if `image_buf` has 4 channels, `frame_np_array.reshape((-1, 3))` failed to reshape the image buffer properly and throw exception.

This can be easily fixed by extracting only rgb channel and ignore the alpha channel from the image buffer.