### PR TITLE
Remove macbeth chart watermark

### DIFF
--- a/packages/open_vp_cal/src/open_vp_cal/framework/generation.py
+++ b/packages/open_vp_cal/src/open_vp_cal/framework/generation.py
@@ -337,14 +337,6 @@ class PatchGeneration:
         self.draw_crosshair(scaled_img, 980, 650, 5, 2, [1.0, 1.0, 1.0])
         self.draw_crosshair(scaled_img, 980, 20, 5, 2, [1.0, 1.0, 1.0])
 
-        text = "Macbeth Chart - OpenVPCal"
-        Oiio.ImageBufAlgo.render_text(
-            scaled_img, 40, 20, text,
-            fontname=ResourceLoader.bold_font(),
-            fontsize=12,
-            textcolor=[1, 1, 1]
-        )
-
         Oiio.ImageBufAlgo.fill(outer_image_buf, [0.1, 0.1, 0.1])
 
         outer_image_buf = imaging_utils.insert_resized_image(scaled_img, outer_image_buf, 20)


### PR DESCRIPTION
# Remove Macbeth chart watermark

## Summary

The watermark added on Macbeth chart was causing `MacBethSample._sample_patch` failure.

During analyse process, OpenVPCal process kept raising error:
```
Lib\site-packages\numpy\_core\fromnumeric.py:3860: RuntimeWarning: Mean of empty slice.
```
This was coming from the call chain:
1. main_window.py: `run_analyse()` calls `self.analyse(led_walls)`
2. application_base.py: `analyse()` creates Processing object and calls
  `processing.run_sampling()`
3. sample_patch.py: `MacBethSample._sample_patch()` calls `np.mean(np.array(samples), 
  axis=0)`

After further investigation, I found that the watermark was causing `detect_colour_checkers_segmentation` failure. Please see the reference image bellow that was generated by `detect_colour_checkers_segmentation(show=True)`.


### Reference 1

<img width="642" height="551" alt="image" src="https://github.com/user-attachments/assets/6d8fa4f1-fec6-4114-bd96-4c5f0bf05eaf" />

### Reference 2

<img width="642" height="551" alt="image" src="https://github.com/user-attachments/assets/b5023d95-7b11-494e-b5d7-cf3ea98ed42e" />

### Old Macbeth Chart without watermark

> OpenVPCal\tests\test_open_vp_cal\resources\RED_WhiteBalance_Test

<img width="825" height="713" alt="image" src="https://github.com/user-attachments/assets/3d9fe597-1c07-4d6b-acea-0e481b43925b" />