### PR TITLE
Reflect change of open_vp_cal for uv sync

### DIFF
--- a/packages/open_vp_cal/pyproject.toml
+++ b/packages/open_vp_cal/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
 ]
 
 [tool.uv.sources]
-open_vp_cal = { path = "src", package = false }
+open_vp_cal = { path = "src" }
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ authors = [
 ]
 license-files = ["LICENSE.md"]
 dependencies = [
-    "open-vp-cal-spg",
-    "open-vp-cal-spg-icvfxpatterns", 
-    "open-vp-cal-stageassets",
     "open-vp-cal",
+    "open-vp-cal-spg",
+    "open-vp-cal-spg-icvfxpatterns",
+    "open-vp-cal-stageassets",
     "pyinstaller>=6.12.0",
     "pytest",
     "ruff",
@@ -39,7 +39,7 @@ select = ["E", "F", "W"]
 ignore = ["E501"]
 
 [tool.uv.sources]
-open-vp-cal = { path = "packages/open_vp_cal" }
+open-vp-cal = { path = "packages/open_vp_cal", editable = true }
 open-vp-cal-spg = { path = "packages/spg" }
 open-vp-cal-spg-icvfxpatterns = { path = "packages/spg_icvfxpatterns" }
 open-vp-cal-stageassets = { path = "packages/stageassets" }

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.11.*"
 resolution-markers = [
     "sys_platform == 'darwin'",
@@ -228,7 +228,7 @@ wheels = [
 [[package]]
 name = "open-vp-cal"
 version = "1.3.0"
-source = { directory = "packages/open_vp_cal" }
+source = { editable = "packages/open_vp_cal" }
 dependencies = [
     { name = "colour-checker-detection" },
     { name = "colour-science" },
@@ -251,6 +251,7 @@ requires-dist = [
     { name = "openimageio", specifier = "==3.0.4.0" },
     { name = "packaging", specifier = ">=24.2" },
     { name = "pyqtgraph", specifier = ">=0.13.7" },
+    { name = "pyright", marker = "extra == 'dev'" },
     { name = "pyside6", specifier = ">=6.8.2.1" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
@@ -379,7 +380,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "open-vp-cal", directory = "packages/open_vp_cal" },
+    { name = "open-vp-cal", editable = "packages/open_vp_cal" },
     { name = "open-vp-cal-spg", directory = "packages/spg" },
     { name = "open-vp-cal-spg-icvfxpatterns", directory = "packages/spg_icvfxpatterns" },
     { name = "open-vp-cal-stageassets", directory = "packages/stageassets" },


### PR DESCRIPTION
# Reflect source changes to `open_vp_cal` when using `uv sync`

## Summary

When running OpenVPCal from the command line using:

- `uv sync`
- `uv run ./packages/open_vp_cal/src/open_vp_cal/main.py --ui True`

updates made in `packages/open_vp_cal/src/open_vp_cal` are not picked up. This occurs because the directory is treated as an installed Python package, and `uv` prioritises the version inside `.venv` rather than the source.

This PR ensures that the source code is used directly, so any changes are immediately reflected when running OpenVPCal via the command line.

Client code that imports the `open_vp_cal` package will not be unaffected.