### PR TITLE
Add base_ocio_config arg for add base_ocio_config for generate_patterns_for_led_walls

### DIFF
--- a/packages/open_vp_cal/src/open_vp_cal/core/ocio_config.py
+++ b/packages/open_vp_cal/src/open_vp_cal/core/ocio_config.py
@@ -188,7 +188,7 @@ class OcioConfigWriter:
         return calibration_cs_name, calibration_cs_description
 
     @staticmethod
-    def get_calibration_space_metadata(led_wall_settings: LedWallSettings) -> [str, str]:
+    def get_calibration_space_metadata(led_wall_settings: LedWallSettings) -> tuple[str, str]:
         """ Get the calibration colour space name
 
         Args:
@@ -914,8 +914,12 @@ class OcioConfigWriter:
         )
 
     def generate_pre_calibration_ocio_config(
-            self, led_walls: List[LedWallSettings],
-            output_file: str = None, base_ocio_config: str = None, preview_export_filter: bool = True) -> str:
+        self,
+        led_walls: List[LedWallSettings],
+        output_file: str | None = None,
+        base_ocio_config: str | None = None,
+        preview_export_filter: bool = True
+    ) -> str:
         """ Generate an OCIO config for pre-calibration with all the necessary colour spaces and transforms.
 
         Args:
@@ -945,8 +949,13 @@ class OcioConfigWriter:
             preview_export_filter=preview_export_filter)
 
     def generate_post_calibration_ocio_config(
-            self, led_walls: List[LedWallSettings], output_file: str = None, base_ocio_config: str = None,
-            preview_export_filter: bool = False, export_lut_for_aces_cct: bool = False) -> str:
+        self,
+        led_walls: List[LedWallSettings],
+        output_file: str | None = None,
+        base_ocio_config: str | None = None,
+        preview_export_filter: bool = False,
+        export_lut_for_aces_cct: bool = False
+    ) -> str:
         """ Generate an OCIO config for post-calibration with all the necessary colour spaces and transforms.
 
         Args:

--- a/packages/open_vp_cal/src/open_vp_cal/framework/utils.py
+++ b/packages/open_vp_cal/src/open_vp_cal/framework/utils.py
@@ -161,7 +161,11 @@ def generate_spg_patterns_for_led_walls(
         ResourceLoader.spg_pattern_basic_config()
     )
 
-def generate_patterns_for_led_walls(project_settings: 'ProjectSettings', led_walls: List['LedWallSettings']) -> str:
+def generate_patterns_for_led_walls(
+    project_settings: 'ProjectSettings',
+    led_walls: List['LedWallSettings'],
+    base_ocio_config: str|None = None,
+) -> str:
     """ For the given list of led walls filter out any walls which are verification walls, then generate the
         calibration patterns for the remaining walls.
 
@@ -180,15 +184,17 @@ def generate_patterns_for_led_walls(project_settings: 'ProjectSettings', led_wal
         patch_generator = PatchGeneration(led_wall)
         patch_generator.generate_patches(constants.PATCHES.patch_order())
 
-    _, ocio_config_path = export_pre_calibration_ocio_config(project_settings, led_walls)
+    _, ocio_config_path = export_pre_calibration_ocio_config(project_settings, led_walls, base_ocio_config)
     return ocio_config_path
 
 
 def export_pre_calibration_ocio_config(
-        project_settings: 'ProjectSettings',
-        led_walls: List['LedWallSettings']) -> tuple[OcioConfigWriter, str]:
+    project_settings: 'ProjectSettings',
+    led_walls: List['LedWallSettings'],
+    base_ocio_config: str|None = None,
+) -> tuple[OcioConfigWriter, str]:
     """ Export the pre calibration ocio config file for the given walls and project settings
 
     """
     config_writer = ocio_config.OcioConfigWriter(project_settings.export_folder)
-    return config_writer, config_writer.generate_pre_calibration_ocio_config(led_walls)
+    return config_writer, config_writer.generate_pre_calibration_ocio_config(led_walls, base_ocio_config=base_ocio_config)


### PR DESCRIPTION
# Add base_ocio_config arg for add base_ocio_config for generate_patterns_for_led_walls

## Summary

I'd like to pass a `base_ocio_config` as an argument for `generate_patterns_for_led_walls`.
This is to support camera colour space that does not exist in OpenVPCal.

Existing behaviour will be same as before.