### PR TITLE
remove redundant attribute that clashed with static method

### DIFF
--- a/packages/open_vp_cal/src/open_vp_cal/framework/generation.py
+++ b/packages/open_vp_cal/src/open_vp_cal/framework/generation.py
@@ -51,7 +51,6 @@ class PatchGeneration:
         """
         self.led_wall = led_wall
         self.patch_size = patch_size
-        self.base_name = None
         self.generation_ocio_config_path = None
 
         self.peak_lum = None


### PR DESCRIPTION
# Remove redundant attribute

## summary

I've recently added a static method `base_name`.
- https://github.com/Netflix/OpenVPCal/pull/90

I found that this was clashed with `PatchGeneration.base_name` attribute, but also `PatchGeneration.base_name` was never used.

So I'm removing a redundant attribute `base_name`.
Sorry for the previous issue. 

<img width="504" height="606" alt="image" src="https://github.com/user-attachments/assets/11176724-3878-407e-a185-f066e84ac010" />
