### PR TITLE
Fix typegen raising exception

### DIFF
--- a/packages/open_vp_cal/src/open_vp_cal/led_wall_settings.py
+++ b/packages/open_vp_cal/src/open_vp_cal/led_wall_settings.py
@@ -21,7 +21,6 @@ import json
 from typing import List, Union, Any, Optional
 from typing import TYPE_CHECKING
 from pydantic import BaseModel, Field, field_validator, PrivateAttr, ConfigDict
-from pydantic.json_schema import SkipJsonSchema
 
 from open_vp_cal.core import constants
 from open_vp_cal.core.structures import ProcessingResults
@@ -82,19 +81,34 @@ class LedWallSettings(BaseModel):
     verification_wall: str = Field(default="")
 
     # ===== Runtime Fields (excluded from serialization) =====
-    processing_results: SkipJsonSchema[ProcessingResults] = Field(
-        default_factory=ProcessingResults,
-        exclude=True
+    _processing_results: ProcessingResults = PrivateAttr(
+        default_factory=ProcessingResults
     )
-    separation_results: SkipJsonSchema[Optional[SeparationResults]] = Field(
+    _separation_results: Optional[SeparationResults] = PrivateAttr(
         default=None,
-        exclude=True
     )
+
+    @property
+    def processing_results(self) -> ProcessingResults:
+        return self._processing_results
+
+    @processing_results.setter
+    def processing_results(self, value: ProcessingResults):
+        self.processing_results = value
+
+    @property
+    def separation_results(self) -> Optional[SeparationResults]:
+        return self._separation_results
+
+    @separation_results.setter
+    def separation_results(self, value: SeparationResults):
+        self._separation_results = value
 
     # ===== Private Attributes (not in schema at all) =====
     _sequence_loader: Optional[SequenceLoader] = PrivateAttr(default=None)
     _sequence_loader_class: type = PrivateAttr(default=SequenceLoader)
     _project_settings: Optional["ProjectSettings"] = PrivateAttr(default=None)
+
 
     @field_validator(
         "roi",

--- a/packages/open_vp_cal/src/open_vp_cal/led_wall_settings.py
+++ b/packages/open_vp_cal/src/open_vp_cal/led_wall_settings.py
@@ -21,6 +21,7 @@ import json
 from typing import List, Union, Any, Optional
 from typing import TYPE_CHECKING
 from pydantic import BaseModel, Field, field_validator, PrivateAttr, ConfigDict
+from pydantic.json_schema import SkipJsonSchema
 
 from open_vp_cal.core import constants
 from open_vp_cal.core.structures import ProcessingResults
@@ -81,11 +82,11 @@ class LedWallSettings(BaseModel):
     verification_wall: str = Field(default="")
 
     # ===== Runtime Fields (excluded from serialization) =====
-    processing_results: ProcessingResults = Field(
+    processing_results: SkipJsonSchema[ProcessingResults] = Field(
         default_factory=ProcessingResults,
         exclude=True
     )
-    separation_results: Optional[SeparationResults] = Field(
+    separation_results: SkipJsonSchema[Optional[SeparationResults]] = Field(
         default=None,
         exclude=True
     )

--- a/packages/open_vp_cal/src/open_vp_cal/project_settings.py
+++ b/packages/open_vp_cal/src/open_vp_cal/project_settings.py
@@ -28,7 +28,6 @@ from pydantic import (
     field_validator,
     field_serializer,
     model_validator,
-    model_serializer,
     PrivateAttr,
     ConfigDict,
 )
@@ -127,16 +126,6 @@ class ProjectSettings(BaseModel):
             )
             return inner
         return data
-
-    @model_serializer(mode='wrap')
-    def serialize_nested(self, handler) -> dict:
-        """Output backwards-compatible nested JSON format."""
-        data = handler(self)
-        version = data.pop('openvp_cal_version', open_vp_cal.__version__)
-        return {
-            constants.OpenVPCalSettingsKeys.VERSION: version,
-            constants.OpenVPCalSettingsKeys.PROJECT_SETTINGS: data
-        }
 
     def __init__(self, led_wall_class: Optional[Type[LedWallSettings]] = None, **data):
         """Initialize a ProjectSettings object.


### PR DESCRIPTION
# Fix typegen raising exception

## Summary

Type generation from pydantic model for the frontend was raising exception below.
This is fix for the issue.

```
  File "C:\dev\plugin\colourcal\backend\.venv\Lib\site-packages\pydantic\json_schema.py", line 2442, in handle_invalid_for_json_schema
    raise PydanticInvalidForJsonSchema(f'Cannot generate a JsonSchema for {error_info}')
pydantic.errors.PydanticInvalidForJsonSchema: Cannot generate a JsonSchema for core_schema.IsInstanceSchema (<class 'open_vp_cal.core.structures.ProcessingResults'>)

For further information visit https://errors.pydantic.dev/2.12/u/invalid-for-json-schema
Error: Failed to export OpenAPI schema
```