### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,14 +35,14 @@ jobs:
     steps:
       - name: Checkout code (no LFS)
         if: ${{ github.event_name == 'schedule' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: dev
           lfs: false
 
       - name: Checkout code (no LFS)
         if: ${{ github.event_name != 'schedule' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           lfs: false
 
@@ -69,7 +69,7 @@ jobs:
 
       # ← Cache all LFS objects between runs
       - name: Cache Git LFS objects
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: .git/lfs/objects
           key: ${{ runner.os }}-git-lfs-${{ hashFiles('**/.gitattributes') }}
@@ -125,7 +125,7 @@ jobs:
 
       # Common Python setup + build + test
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -168,20 +168,20 @@ jobs:
     steps:
       - name: Checkout code (no LFS)
         if: ${{ github.event_name == 'schedule' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: dev
           lfs: false
 
       - name: Checkout code (no LFS)
         if: ${{ github.event_name != 'schedule' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           lfs: false
 
       # Common Python setup + build + test
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -213,7 +213,7 @@ jobs:
 
       # ← Cache LFS objects for nightly packaging too
       - name: Cache Git LFS objects
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: .git/lfs/objects
           key: nightly-${{ runner.os }}-git-lfs-${{ hashFiles('**/.gitattributes') }}
@@ -288,28 +288,28 @@ jobs:
 
       - name: Upload macOS nightly artifact
         if: runner.os == 'macOS'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: nightly-macos
           path: './dist/OpenVPCal-*.dmg'
 
       - name: Upload Windows nightly artifact - Zip
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: nightly-windows-setup
           path: 'Output/OpenVPCal*.exe'
 
       - name: Upload Windows nightly artifact - Setup
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: nightly-windows-zip
           path: 'Output/OpenVPCal*.zip'
 
       - name: Upload Linux nightly artifact
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: nightly-linux
           path: 'Output/OpenVPCal*.zip'
@@ -336,7 +336,7 @@ jobs:
 
     steps:
       - name: Checkout tagged commit (no LFS, full history for branch check)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
           lfs: false
@@ -355,7 +355,7 @@ jobs:
 
       # Common Python setup
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -387,7 +387,7 @@ jobs:
 
       # ← Cache LFS objects for release packaging
       - name: Cache Git LFS objects
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: .git/lfs/objects
           key: release-${{ runner.os }}-git-lfs-${{ hashFiles('**/.gitattributes') }}
@@ -436,28 +436,28 @@ jobs:
       # Upload artifacts for release
       - name: Upload macOS release artifact
         if: runner.os == 'macOS'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-macos
           path: './dist/OpenVPCal-*.dmg'
 
       - name: Upload Windows release artifact - Setup
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-windows-setup
           path: 'Output/OpenVPCal*.exe'
 
       - name: Upload Windows release artifact - Zip
         if: runner.os == 'Windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-windows-zip
           path: 'Output/OpenVPCal*.zip'
 
       - name: Upload Linux release artifact
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-linux
           path: 'Output/OpenVPCal*.zip'
@@ -476,7 +476,7 @@ jobs:
       contents: write
     steps:
       - name: Download all build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: release-assets
           merge-multiple: true


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache` | [`v3`](https://github.com/actions/cache/releases/tag/v3) | [`v5`](https://github.com/actions/cache/releases/tag/v5) | [Release](https://github.com/actions/cache/releases/tag/v5) | main.yml |
| `actions/checkout` | [`v3`](https://github.com/actions/checkout/releases/tag/v3) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | main.yml |
| `actions/download-artifact` | [`v4`](https://github.com/actions/download-artifact/releases/tag/v4) | [`v7`](https://github.com/actions/download-artifact/releases/tag/v7) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) | main.yml |
| `actions/setup-python` | [`v4`](https://github.com/actions/setup-python/releases/tag/v4) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | main.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v6`](https://github.com/actions/upload-artifact/releases/tag/v6) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | main.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### ⚠️ Breaking Changes

- **actions/cache** (v3 → v5):
  - ⚠️ v4 uses a new caching backend - existing caches may not be reused on first run

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
